### PR TITLE
Feat: Support DJS version Lower (KoreanbotsClient)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ widget.getVoteWidget(client.user.id, "jpeg").then(w => {
 
 ## 테스트하기
 
-- discord.js v12 : 자동 업데이트 
+- discord.js : 자동 업데이트 
 
-**주의:** *이 KoreanbotsClient는 discord.js v12에서만 작동합니다.*
+**주의:** *이 KoreanbotsClient는 discord.js v11,12에서 작동합니다.*
 ```js
 const { KoreanbotsClient } = require("koreanbots")
 const client = new KoreanbotsClient({

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@discordjs/collection": "^0.1.6",
-    "discord.js": "^12.2.0",
+    "discord.js": ">=11.0.0",
     "node-fetch": "^2.6.0",
     "sharp": "^0.25.4"
   },

--- a/src/KoreanbotsClient.js
+++ b/src/KoreanbotsClient.js
@@ -3,7 +3,7 @@ const DjsVersion = version ? parseInt(version.split(".")[0]) : null
 class KoreanbotsClient extends Client {
     constructor(options = {}) {
         super(options)
-
+        if(!DjsVersion) throw new Error('Can't find Discord.js Version. (It will be >= 9.3.0)');
         this.options.koreanbotsToken = options.koreanbotsToken || null
         this.options.koreanbotsOptions = options.koreanbotsOptions || new Object()
         this.options.koreanbotsOptions.interval = options.koreanbotsOptions.interval || 60000 * 30
@@ -14,12 +14,12 @@ class KoreanbotsClient extends Client {
     }
 
     _update() {
-        const GuildCount = DjsVersion && DjsVersion >= 12 ? this.guilds.cache.size : this.guilds.size
+        const GuildCount = DjsVersion >= 12 ? this.guilds.cache.size : this.guilds.size
         return this.koreanbots.update(GuildCount)
     }
 
     _ok() {
-        const GuildCount = DjsVersion && DjsVersion >= 12 ? this.guilds.cache.size : this.guilds.size
+        const GuildCount = DjsVersion >= 12 ? this.guilds.cache.size : this.guilds.size
         if (!GuildCount) return setTimeout(this._ok, 1000)
 
         const { MyBot } = require("./")

--- a/src/KoreanbotsClient.js
+++ b/src/KoreanbotsClient.js
@@ -14,12 +14,12 @@ class KoreanbotsClient extends Client {
     }
 
     _update() {
-        const GuildCount = DjsVersion && DjsVersion <= 12 ? this.guilds.cache.size : this.guilds.size
+        const GuildCount = DjsVersion && DjsVersion >= 12 ? this.guilds.cache.size : this.guilds.size
         return this.koreanbots.update(GuildCount)
     }
 
     _ok() {
-        const GuildCount = DjsVersion && DjsVersion <= 12 ? this.guilds.cache.size : this.guilds.size
+        const GuildCount = DjsVersion && DjsVersion >= 12 ? this.guilds.cache.size : this.guilds.size
         if (!GuildCount) return setTimeout(this._ok, 1000)
 
         const { MyBot } = require("./")

--- a/src/KoreanbotsClient.js
+++ b/src/KoreanbotsClient.js
@@ -1,5 +1,5 @@
 const { Client,version } = require("discord.js")
-
+const djsver = version.split(".")[0]
 class KoreanbotsClient extends Client {
     constructor(options = {}) {
         super(options)
@@ -14,12 +14,13 @@ class KoreanbotsClient extends Client {
     }
 
     _update() {
-        const djsver = version.split(".")[0]
-        return this.koreanbots.update(djsver == "11" ? this.guilds.size : this.guilds.cache.size)
+        const guildcount = djsver == "11" ? this.guilds.size : this.guilds.cache.size
+        return this.koreanbots.update(guildcount)
     }
 
     _ok() {
-        if (!this.guilds.cache.size) return setTimeout(this._ok, 1000)
+        const guildcount = djsver == "11" ? this.guilds.size : this.guilds.cache.size
+        if (!guildcount) return setTimeout(this._ok, 1000)
 
         const { MyBot } = require("./")
         this.koreanbots = new MyBot(this.options.koreanbotsToken, this.options.koreanbotsOptions)

--- a/src/KoreanbotsClient.js
+++ b/src/KoreanbotsClient.js
@@ -1,9 +1,12 @@
 const { Client,version } = require("discord.js")
 const DjsVersion = version ? parseInt(version.split(".")[0]) : null
+
 class KoreanbotsClient extends Client {
     constructor(options = {}) {
         super(options)
-        if(!DjsVersion) throw new Error("Can't find Discord.js Version. (It will be >= 9.3.0)")
+
+        if(!DjsVersion) throw new Error("discord.js 버전을 찾을수 없습니다. Discord.js가 설치 되었는지 확인해 주세요.")
+
         this.options.koreanbotsToken = options.koreanbotsToken || null
         this.options.koreanbotsOptions = options.koreanbotsOptions || new Object()
         this.options.koreanbotsOptions.interval = options.koreanbotsOptions.interval || 60000 * 30
@@ -13,14 +16,20 @@ class KoreanbotsClient extends Client {
         this.once("ready", this._ok)
     }
 
+    get _getGuildCount() {
+        return DjsVersion >= 12 ? this.guilds.cache.size : this.guilds.size
+    }
+
+    set _getGuildCount(v) {
+       throw new Error("Can't modify value as " + v)
+    }
+
     _update() {
-        const GuildCount = DjsVersion >= 12 ? this.guilds.cache.size : this.guilds.size
-        return this.koreanbots.update(GuildCount)
+        return this.koreanbots.update(this._getGuildCount)
     }
 
     _ok() {
-        const GuildCount = DjsVersion >= 12 ? this.guilds.cache.size : this.guilds.size
-        if (!GuildCount) return setTimeout(this._ok, 1000)
+        if (!this._getGuildCount) return setTimeout(() => this._ok(), 1000)
 
         const { MyBot } = require("./")
         this.koreanbots = new MyBot(this.options.koreanbotsToken, this.options.koreanbotsOptions)

--- a/src/KoreanbotsClient.js
+++ b/src/KoreanbotsClient.js
@@ -3,7 +3,7 @@ const DjsVersion = version ? parseInt(version.split(".")[0]) : null
 class KoreanbotsClient extends Client {
     constructor(options = {}) {
         super(options)
-        if(!DjsVersion) throw new Error('Can't find Discord.js Version. (It will be >= 9.3.0)');
+        if(!DjsVersion) throw new Error("Can't find Discord.js Version. (It will be >= 9.3.0)")
         this.options.koreanbotsToken = options.koreanbotsToken || null
         this.options.koreanbotsOptions = options.koreanbotsOptions || new Object()
         this.options.koreanbotsOptions.interval = options.koreanbotsOptions.interval || 60000 * 30

--- a/src/KoreanbotsClient.js
+++ b/src/KoreanbotsClient.js
@@ -1,5 +1,5 @@
 const { Client,version } = require("discord.js")
-const djsver = version.split(".")[0]
+const DjsVersion = version ? parseInt(version.split(".")[0]) : null
 class KoreanbotsClient extends Client {
     constructor(options = {}) {
         super(options)
@@ -14,13 +14,13 @@ class KoreanbotsClient extends Client {
     }
 
     _update() {
-        const guildcount = djsver == "11" ? this.guilds.size : this.guilds.cache.size
-        return this.koreanbots.update(guildcount)
+        const GuildCount = DjsVersion && DjsVersion <= 12 ? this.guilds.cache.size : this.guilds.size
+        return this.koreanbots.update(GuildCount)
     }
 
     _ok() {
-        const guildcount = djsver == "11" ? this.guilds.size : this.guilds.cache.size
-        if (!guildcount) return setTimeout(this._ok, 1000)
+        const GuildCount = DjsVersion && DjsVersion <= 12 ? this.guilds.cache.size : this.guilds.size
+        if (!GuildCount) return setTimeout(this._ok, 1000)
 
         const { MyBot } = require("./")
         this.koreanbots = new MyBot(this.options.koreanbotsToken, this.options.koreanbotsOptions)

--- a/src/KoreanbotsClient.js
+++ b/src/KoreanbotsClient.js
@@ -1,4 +1,4 @@
-const { Client } = require("discord.js")
+const { Client,version } = require("discord.js")
 
 class KoreanbotsClient extends Client {
     constructor(options = {}) {
@@ -14,7 +14,8 @@ class KoreanbotsClient extends Client {
     }
 
     _update() {
-        return this.koreanbots.update(this.guilds.cache.size)
+        const djsver = version.split(".")[0]
+        return this.koreanbots.update(djsver == "11" ? this.guilds.size : this.guilds.cache.size)
     }
 
     _ok() {

--- a/src/KoreanbotsClient.js
+++ b/src/KoreanbotsClient.js
@@ -21,7 +21,7 @@ class KoreanbotsClient extends Client {
     }
 
     set _getGuildCount(v) {
-       throw new Error("Can't modify value as " + v)
+        throw new Error("Can't modify value as " + v)
     }
 
     _update() {


### PR DESCRIPTION
Discord.js (이하 djs) 라이브러리 major 버전을 가져와 v11도 자동으로 호환이 되게 변경하였습니다. ~~(v11 미만은 안쳐다봅니다.)~~

추후 나오는 major 버전도 v12와 사용법이 같다고 생각하기에 v11만 따로 설정하였습니다.

djs 호환성을 위해 버전이 낮아짐에 따라 요구하는 종속 라이브러리 버전 조건도 변경하였습니다.
node 요구 버전도 변경할려고 했으나
추후에 기능 추가 관한 버전 이슈 & 기타 문제 때문에 조심스러워서 keep 하였습니다.